### PR TITLE
Fix #11: exact CPython ABI-tag matching in check-release-fileset

### DIFF
--- a/actions/check-release-fileset/README.md
+++ b/actions/check-release-fileset/README.md
@@ -92,6 +92,12 @@ Newline or comma-separated list of required wheel targets and source distributio
   - `manylinux_2_34`: glibc 2.34+ (Debian 11+, Ubuntu 21.10+, RHEL 9+)
   - `manylinux_2_36`: glibc 2.36+ (Debian 12+, Ubuntu 22.10+)
 
+> **CPython GIL vs free-threaded:** for CPython the `version` selects the **ABI tag**, which
+> is matched *exactly*. `314` requires a GIL `cp314` wheel and `314t` requires a
+> free-threaded `cp314t` wheel — a `cp314t` wheel will **not** satisfy a `cpy314` target
+> (and vice-versa). The trailing `t` denotes the free-threaded ABI (`cp314t`); it is not
+> part of the Python tag (which is `cp314` in both cases).
+
 #### Special Keywords
 
 - `source` or `sdist`: Require source distribution (`.tar.gz`)

--- a/actions/check-release-fileset/action.yml
+++ b/actions/check-release-fileset/action.yml
@@ -315,13 +315,18 @@ runs:
                 continue
               fi
 
-              # Match implementation and version
-              # CPython: cp311, cp312, etc.
+              # Match implementation and version.
+              # CPython: the python tag is cp<N> for BOTH GIL and free-threaded builds
+              #          (e.g. cp314); the GIL vs free-threaded distinction lives ONLY in
+              #          the ABI tag (cp314 vs cp314t), checked exactly just below.
               # PyPy: pp311, pp38, pypy311_pp73, etc.
 
               python_tag_matches=false
               if [ "$req_impl" = "cp" ]; then
-                if [[ "$wheel_python" =~ ^cp${req_version} ]]; then
+                # Strip a trailing 't' (free-threaded marker) before matching the python
+                # tag, since the python tag never carries it (the 't' is on the ABI tag).
+                req_version_num="${req_version%t}"
+                if [[ "$wheel_python" == "cp${req_version_num}" ]]; then
                   python_tag_matches=true
                 fi
               elif [ "$req_impl" = "pp" ]; then
@@ -332,6 +337,17 @@ runs:
 
               if [ "$python_tag_matches" = "false" ]; then
                 continue
+              fi
+
+              # For CPython, require an EXACT ABI-tag match so a free-threaded cp314t wheel
+              # never satisfies a GIL cp314 target (and vice-versa). Expected ABI tag is
+              # cp<version> -- cp314 (GIL) or cp314t (free-threaded) -- where req_version
+              # already carries the trailing 't' for free-threaded targets. This is distinct
+              # from the manylinux platform tag checked further below. (wamp-cicd #11)
+              if [ "$req_impl" = "cp" ]; then
+                if [[ "$wheel_abi" != "cp${req_version}" ]]; then
+                  continue
+                fi
               fi
 
               # Match platform

--- a/justfile
+++ b/justfile
@@ -64,3 +64,9 @@ deploy-github-templates:
     echo "   - Issue templates: ../.github/ISSUE_TEMPLATE/"
     echo "   - PR template: ../.github/pull_request_template.md"
     echo "   Now add & commit the templates in the target repository."
+
+# Run the action unit tests (composite-action shell logic against crafted fixtures).
+test:
+    #!/usr/bin/env bash
+    set -e
+    bash tests/test-check-release-fileset.sh

--- a/tests/test-check-release-fileset.sh
+++ b/tests/test-check-release-fileset.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Test for actions/check-release-fileset ABI-tag matching (wamp-cicd #11).
+#
+# Extracts the composite action's `run:` script from action.yml and drives it
+# against crafted dist/ filesets, asserting that a free-threaded cp314t wheel
+# does NOT satisfy a GIL cp314 target (and vice-versa), plus regression coverage
+# for the existing CPython/PyPy/macOS/Windows/source targets.
+#
+# Run: bash tests/test-check-release-fileset.sh
+#
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTION_YML="${HERE}/../actions/check-release-fileset/action.yml"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Extract the composite action's `run: |` block and dedent the 8-space YAML
+# indentation, so we exercise the REAL production shell (no duplicated logic).
+SCRIPT="${WORK}/fileset.sh"
+awk '/^      run: \|/{f=1;next} /^branding:/{f=0} f' "$ACTION_YML" | sed 's/^        //' > "$SCRIPT"
+if [ ! -s "$SCRIPT" ]; then
+  echo "FATAL: could not extract run: script from $ACTION_YML" >&2
+  exit 2
+fi
+
+PASS=0
+FAIL=0
+
+# run_case <name> <expected_exit> <targets> <dist-file>...
+run_case() {
+  local name="$1" expected="$2" targets="$3"; shift 3
+  local dist="${WORK}/dist"
+  rm -rf "$dist"; mkdir -p "$dist"
+  local f
+  for f in "$@"; do : > "${dist}/${f}"; done
+  : > "${WORK}/gh_output"
+  local rc=0
+  env DISTDIR="$dist" TARGETS="$targets" MODE=strict \
+      ALLOW_DEV_WHEELS=false ALLOW_EXTRA_WHEELS=false KEEP_METADATA=true \
+      GITHUB_OUTPUT="${WORK}/gh_output" \
+      bash "$SCRIPT" > "${WORK}/log" 2>&1 || rc=$?
+  if [ "$rc" = "$expected" ]; then
+    echo "  ok   [$name] exit=$rc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL [$name] exit=$rc (expected $expected)"
+    tail -8 "${WORK}/log" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+V="26.7.1"  # arbitrary version string for the fixture filenames
+
+echo "== ABI-tag correctness (the #11 fix) =="
+# GIL cp314 target must REJECT a free-threaded cp314t wheel (-> missing -> fail)
+run_case "cpy314 rejects cp314t (aarch64)" 1 "cpy314-linux-aarch64-manylinux_2_28" \
+  "pkg-${V}-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+# GIL cp314 target ACCEPTS a proper cp314 wheel
+run_case "cpy314 accepts cp314 (aarch64)" 0 "cpy314-linux-aarch64-manylinux_2_28" \
+  "pkg-${V}-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+# free-threaded cpy314t target ACCEPTS its cp314t wheel
+run_case "cpy314t accepts cp314t (aarch64)" 0 "cpy314t-linux-aarch64-manylinux_2_28" \
+  "pkg-${V}-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+# free-threaded cpy314t target REJECTS a GIL cp314 wheel
+run_case "cpy314t rejects cp314 (aarch64)" 1 "cpy314t-linux-aarch64-manylinux_2_28" \
+  "pkg-${V}-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl"
+
+echo "== regressions (existing targets unaffected) =="
+run_case "cpy311 accepts cp311" 0 "cpy311-linux-x86_64-manylinux_2_28" \
+  "pkg-${V}-cp311-cp311-manylinux_2_28_x86_64.whl"
+run_case "cpy311 rejects cp314" 1 "cpy311-linux-x86_64-manylinux_2_28" \
+  "pkg-${V}-cp314-cp314-manylinux_2_28_x86_64.whl"
+run_case "pypy311 accepts pypy311_pp73" 0 "pypy311-linux-aarch64-manylinux_2_34" \
+  "pkg-${V}-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl"
+run_case "macos cp314 arm64" 0 "cpy314-macos-arm64" \
+  "pkg-${V}-cp314-cp314-macosx_15_0_arm64.whl"
+run_case "win cp314 amd64" 0 "cpy314-win-amd64" \
+  "pkg-${V}-cp314-cp314-win_amd64.whl"
+run_case "source required present" 0 "source" \
+  "pkg-${V}.tar.gz"
+
+echo ""
+echo "TOTAL: pass=${PASS} fail=${FAIL}"
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
fixes https://github.com/wamp-proto/wamp-cicd/issues/11

----

The release fileset validator extracted the wheel ABI tag but never compared it, matching only on the python tag (cp314, identical for GIL and free-threaded). A free-threaded cp314t wheel therefore satisfied a GIL cp314 target -- the release-gate reason the aarch64 cp314t wheel shipped in the cp314 slot (autobahn-python #1875 / zlmdb #124). A cpy314t target also could never match its own wheel, because the trailing `t` was tested against the python tag rather than the ABI tag.

Match the python tag on the numeric version (strip trailing `t`) and add an exact CPython ABI-tag check (wheel_abi == cp<version>: cp314 for GIL, cp314t for free-threaded). PyPy is unaffected (ABI pypy311_pp73). After the fix a cp314t wheel in a cp314 slot becomes an unmatched extra + missing target -> strict-mode failure.

Add tests/test-check-release-fileset.sh (run via `just test`), which extracts the composite action's real run: shell and drives it against crafted dist/ fixtures: cp314t rejected for cpy314, cp314t accepted for cpy314t, plus regressions for cp311/pypy/macos/win/source. Verified red->green (the pre-fix action wrongly accepted cp314t; the fix rejects it; 10/10 pass). Documented the exact GIL/free-threaded ABI matching in the action README.

Note: This work was completed with AI assistance (Claude Code).